### PR TITLE
Added a period to "access: PERMISSION DENIED"

### DIFF
--- a/static/js/jurassicSystems.js
+++ b/static/js/jurassicSystems.js
@@ -164,7 +164,7 @@
                'AUTHOR\n' +
                '\tWritten by Dennis Nedry.\n',
       command: function(env, inputLine) {
-          var output = $('<span>').text('access: PERMISSION DENIED');
+          var output = $('<span>').text('access: PERMISSION DENIED.');
           var arg = inputLine.split(/ +/)[1] || '';
           var magicWord = inputLine.substring(inputLine.trim()
                                    .lastIndexOf(' ')) || '';


### PR DESCRIPTION
In the movie, there is a period at the end of "PERMISSION DENIED". In lockdown on your system, it looks like "access: PERMISSION DENIED...and....(newline)"
Also, the newline should only happen when "YOU DIDN'T SAY THE MAGIC WORD" starts spamming. I can't find where that function is, though